### PR TITLE
Update fingerprint, allow for user to specify fingerprint

### DIFF
--- a/Conduit.cpp
+++ b/Conduit.cpp
@@ -20,13 +20,13 @@ char response_with_quotes[30];
 WiFiClient client;
 SocketIoClient webSocket;
 ESP8266WiFiMulti WiFiMulti;
-const char* fingerprint = "BC:E5:91:A5:68:B6:EF:93:A6:82:5A:23:85:45:F8:70:3C:21:F3:AE";
 
-Conduit::Conduit(const char* name, const char* server, const char* firmware_key){
+Conduit::Conduit(const char* name, const char* server, const char* firmware_key, const char* fingerprint) {
     // Set name and server
     this->_name = name;
     this->_conduit_server = server;
     this->_firmware_key = firmware_key;
+    this->_fingerprint = fingerprint;
 
     // Compute _prefixed_name
     strcpy(prefixed_name, "\"");
@@ -76,7 +76,7 @@ Conduit& Conduit::init(){
     this->_client->on("server_directives", onCall);
     this->_client->on("connect", onConnect);
     //this->_client->begin(this->_conduit_server, 8000, "/socket.io/?transport=websocket");
-    this->_client->beginSSL(this->_conduit_server, PORT, "/socket.io/?transport=websocket", fingerprint);
+    this->_client->beginSSL(this->_conduit_server, PORT, "/socket.io/?transport=websocket", this->_fingerprint);
     for (int i=0; i < 5; i++) {
         webSocket.loop();
     }

--- a/Conduit.h
+++ b/Conduit.h
@@ -17,6 +17,7 @@ device and decide what funciton to all is abstracted away entirely by this libra
 #include <SocketIoClient.h>
 #include <Hash.h>
 #include <RequestParams.h>
+#define default_fingerprint "62:78:3B:79:74:10:4B:EE:5C:DD:E6:0A:BA:59:4F:DC:FF:00:18:C3"
 
 typedef std::function<int (RequestParams* rp)> handler;
 void removeSpace(char* s);
@@ -31,8 +32,9 @@ private:
 	const char* _firmware_key;
 	std::map<String, handler> _f_map;
     const char* _sid;
-public:
-	Conduit(const char* name, const char* server, const char* firmware_key);
+	const char* _fingerprint;
+public: 
+	Conduit(const char* name, const char* server, const char* firmware_key, const char* fingerprint = default_fingerprint); 
 	Conduit& init();
     void initConnection();
 	void addHandler(const char* name, handler f);

--- a/library.json
+++ b/library.json
@@ -20,7 +20,7 @@
 	"WebSockets": "2.1.0",
 	"SocketIoClient": "0.2"
   },
-  "version": "2.0.0",
+  "version": "2.1.0",
   "frameworks": "arduino",
   "platforms": "espressif8266"
 }


### PR DESCRIPTION
Update to new default SSL fingerprint for `api.conduit.suyash.io` (closes #6) and allows for the user of this library to specify a fingerprint of their own if they choose. 

Of course, ideally no fingerprint would be needed for verification (and we could just verify by checking the certificate chain against a known root certificate). This change requires downstream changes in other libraries, however, and is being tracked by #5. 